### PR TITLE
Replace freenode references with libera chat

### DIFF
--- a/greenfield/source/core/convert/src/ffmpeg-3.4.2/RELEASE_NOTES
+++ b/greenfield/source/core/convert/src/ffmpeg-3.4.2/RELEASE_NOTES
@@ -10,6 +10,7 @@
    complete Git history on http://source.ffmpeg.org.
 
    We hope you will like this release as much as we enjoyed working on it, and
-   as usual, if you have any questions about it, or any FFmpeg related topic,
-   feel free to join us on the #ffmpeg IRC channel (on irc.freenode.net) or ask
-   on the mailing-lists.
+   as usual, if you have any questions about it or any FFmpeg-related topic,
+   feel free to join us on the Gitter chat channel at https://gitter.im/aboutcode-org/discuss .
+   You can also use your favorite IRC client or use the webchat
+   at https://web.libera.chat/?#aboutcode or ask on the mailing lists.

--- a/greenfield/source/core/convert/src/ffmpeg-3.4.2/configure
+++ b/greenfield/source/core/convert/src/ffmpeg-3.4.2/configure
@@ -498,7 +498,7 @@ die(){
 
 If you think configure made a mistake, make sure you are using the latest
 version from Git.  If the latest version fails, report the problem to the
-ffmpeg-user@ffmpeg.org mailing list or IRC #ffmpeg on irc.freenode.net.
+ffmpeg-user@ffmpeg.org mailing list or IRC #aboutcode on web.libera.chat
 EOF
     if disabled logging; then
         cat <<EOF

--- a/greenfield/source/core/convert/src/ffmpeg-3.4.2/doc/mailing-list-faq.texi
+++ b/greenfield/source/core/convert/src/ffmpeg-3.4.2/doc/mailing-list-faq.texi
@@ -186,7 +186,7 @@ Perform a site search using your favorite search engine. Example:
 
 @section Is there an alternative to the mailing list?
 
-You can ask for help in the official @t{#ffmpeg} IRC channel on Freenode.
+You can ask for help in the official @t{#aboutcode} IRC channel on liberachat.
 
 Some users prefer the third-party Nabble interface which presents the
 mailing lists in a typical forum layout.

--- a/greenfield/source/core/convert/src/ffmpeg-3.4.2/doc/writing_filters.txt
+++ b/greenfield/source/core/convert/src/ffmpeg-3.4.2/doc/writing_filters.txt
@@ -419,5 +419,7 @@ done:
  - git add ... && git commit -m "avfilter: add foobar filter." && git format-patch -1
 
 When all of this is done, you can submit your patch to the ffmpeg-devel
-mailing-list for review.  If you need any help, feel free to come on our IRC
-channel, #ffmpeg-devel on irc.freenode.net.
+mailing-list for review. If you need any help, feel free to join us on
+the Gitter chat channel at https://gitter.im/aboutcode-org/discuss .
+You can also use your favorite IRC client or use the webchat
+at https://web.libera.chat/?#aboutcode.


### PR DESCRIPTION
**Reference Issues/PRs**

Fixes [Replace references to freenode #92](https://github.com/nexB/aboutcode/issues/92)

**What does this implement/fix? Explain your changes.**
There were some outdated freenode references present in RELEASE_NOTES and writing_filters so replaced this address with the official IRC channel i.e Gitter and liberachat

**Any other comments?**
Thank You!